### PR TITLE
OUT-263 | Bump copilot-node-sdk to 2.0.0 on all 3 apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-select": "^2.0.0",
     "@sentry/nextjs": "^7.105.0",
     "@vercel/postgres": "^0.5.0",
-    "copilot-node-sdk": "^1.2.2",
+    "copilot-node-sdk": "^2.0.0",
     "dotenv-run-script": "^0.4.1",
     "next": "^14.0.4",
     "next-plugin-svgr": "^1.1.8",

--- a/src/app/api/messages/services/message.service.ts
+++ b/src/app/api/messages/services/message.service.ts
@@ -6,7 +6,7 @@ import { SettingResponse } from '@/types/setting';
 import { Message, SendMessageRequestSchema } from '@/types/message';
 import DBClient from '@/lib/db';
 import { z } from 'zod';
-import { ApiError } from 'copilot-node-sdk/codegen/api';
+import { CopilotAPIError } from '@/exceptions/copilot';
 
 export class MessageService {
   private prismaClient: PrismaClient = DBClient.getInstance();
@@ -51,7 +51,7 @@ export class MessageService {
         await this.sendMessage(copilotClient, setting, message);
       }
     } catch (e: unknown) {
-      if (e instanceof ApiError) {
+      if (e instanceof CopilotAPIError) {
         if (e.request?.errors && e.request.errors['404'] === '404') {
           return;
         }

--- a/src/app/api/messages/services/message.service.ts
+++ b/src/app/api/messages/services/message.service.ts
@@ -52,8 +52,7 @@ export class MessageService {
       }
     } catch (e: unknown) {
       if (matchesCopilotApiError(e)) {
-        const castedErr = e as CopilotAPIError;
-        if (castedErr.request?.errors && castedErr.request.errors['404'] === '404') {
+        if (e.request?.errors && e.request.errors['404'] === '404') {
           return;
         }
       }

--- a/src/app/api/messages/services/message.service.ts
+++ b/src/app/api/messages/services/message.service.ts
@@ -6,7 +6,7 @@ import { SettingResponse } from '@/types/setting';
 import { Message, SendMessageRequestSchema } from '@/types/message';
 import DBClient from '@/lib/db';
 import { z } from 'zod';
-import { CopilotAPIError } from '@/exceptions/copilot';
+import { CopilotAPIError, matchesCopilotApiError } from '@/exceptions/copilot';
 
 export class MessageService {
   private prismaClient: PrismaClient = DBClient.getInstance();
@@ -51,8 +51,9 @@ export class MessageService {
         await this.sendMessage(copilotClient, setting, message);
       }
     } catch (e: unknown) {
-      if (e instanceof CopilotAPIError) {
-        if (e.request?.errors && e.request.errors['404'] === '404') {
+      if (matchesCopilotApiError(e)) {
+        const castedErr = e as CopilotAPIError;
+        if (castedErr.request?.errors && castedErr.request.errors['404'] === '404') {
           return;
         }
       }

--- a/src/app/api/settings/services/setting.service.ts
+++ b/src/app/api/settings/services/setting.service.ts
@@ -20,6 +20,8 @@ export class SettingService {
 
   async save(requestData: SettingRequest, { apiToken }: { apiToken: string }): Promise<void> {
     const currentUser = await getCurrentUser(apiToken);
+    if (!currentUser) throw new Error('No user associated with this session');
+
     const currentWorkspace = await getWorkspace(apiToken);
 
     const settingByWorkspace = await this.prismaClient.setting.findFirst({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { SettingResponse } from '@/types/setting';
 import AutoResponder from '@/app/components/AutoResponder';
 import { SettingService } from '@/app/api/settings/services/setting.service';
 import { CopilotAPI } from '@/utils/copilotApiUtils';
-import { ClientResponse, CompanyResponse, MeResponse, InternalUsers, InternalUser, WorkspaceResponse } from '@/types/common';
+import { ClientResponse, CompanyResponse, InternalUsers, InternalUser, WorkspaceResponse } from '@/types/common';
 import { z } from 'zod';
 import appConfig from '@/config/app';
 import InvalidToken from './components/InvalidToken';
@@ -14,12 +14,16 @@ type SearchParams = { [key: string]: string | string[] | undefined };
 
 const settingsService = new SettingService();
 
-async function getContent(searchParams: SearchParams) {
+async function getContent(searchParams: SearchParams): Promise<{
+  client?: ClientResponse;
+  company?: CompanyResponse;
+  workspace?: WorkspaceResponse;
+  currentUserId?: string;
+}> {
   if (!searchParams.token) {
     return {
       client: undefined,
       company: undefined,
-      me: undefined,
     };
   }
 
@@ -27,7 +31,6 @@ async function getContent(searchParams: SearchParams) {
   const result: {
     client?: ClientResponse;
     company?: CompanyResponse;
-    me?: MeResponse;
     workspace?: WorkspaceResponse;
     currentUserId?: string;
   } = {};
@@ -37,7 +40,6 @@ async function getContent(searchParams: SearchParams) {
     result.currentUserId = payload?.internalUserId;
   }
 
-  result.me = await copilotAPI.me();
   result.workspace = await copilotAPI.getWorkspace();
 
   if (searchParams.clientId && typeof searchParams.clientId === 'string') {

--- a/src/exceptions/copilot.ts
+++ b/src/exceptions/copilot.ts
@@ -6,6 +6,6 @@ export declare class CopilotAPIError {
   };
 }
 
-export const matchesCopilotApiError = (err: unknown) => {
+export const matchesCopilotApiError = (err: unknown): err is CopilotAPIError => {
   return !!(err as any)?.request?.errors?.length;
 };

--- a/src/exceptions/copilot.ts
+++ b/src/exceptions/copilot.ts
@@ -1,7 +1,11 @@
 export declare class CopilotAPIError {
   request: {
     errors: {
-      '404': '404' | null | undefined;
+      '404': '404' | string;
     };
   };
 }
+
+export const matchesCopilotApiError = (err: unknown) => {
+  return !!(err as any)?.request?.errors?.length;
+};

--- a/src/exceptions/copilot.ts
+++ b/src/exceptions/copilot.ts
@@ -1,0 +1,7 @@
+export declare class CopilotAPIError {
+  request: {
+    errors: {
+      '404': '404' | null | undefined;
+    };
+  };
+}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -19,7 +19,7 @@ export async function getWorkspace(apiToken: string): Promise<WorkspaceResponse>
   return await copilotClient.getWorkspace();
 }
 
-export async function getCurrentUser(apiToken: string): Promise<MeResponse> {
+export async function getCurrentUser(apiToken: string): Promise<MeResponse | null> {
   const copilotClient = new CopilotAPI(apiToken);
   return await copilotClient.me();
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,10 +2810,10 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-copilot-node-sdk@^1.2.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/copilot-node-sdk/-/copilot-node-sdk-1.3.0.tgz#1812340981cd7034800d605039b6bd49851e8050"
-  integrity sha512-7RTAWVN2qjWstq5gnERl3r14hMiyFvWz7l15+FbjFC0t1GQyg8kq4vDGHXHOpLmWlHvVBA08cqsA+pL2p6LMHw==
+copilot-node-sdk@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/copilot-node-sdk/-/copilot-node-sdk-2.0.0.tgz#d70af16a552ef8bea42288c446637cb156a615d8"
+  integrity sha512-9LqBbRxBhMfKJWy3I3ez7GoiQbU7qvbbBrMhRNs+1G09tHsvuZGmGKbFBPiKVwSOnxH83a8GkmO8j09kGb8Hpg==
   dependencies:
     isomorphic-fetch "^3.0.0"
     jsonwebtoken "^9.0.2"


### PR DESCRIPTION
Changes:
- [x]  Completely change util class to support new sdk methods
- [x]  Change types for SDK returns, as per new SDK version
- [x]  Deprecate all uses of /me endpoint since it only returns data about user that generates API key - replace it with 
- [x]  Favor getTokenPayload use as it is the new source of client/IU/workspace data
- [x]  Fix issue with previous apps where company field was assumed to always be present for a client