### PR TITLE
OUT-2106 | Autoresponder sending messages without being triggered by a client message

### DIFF
--- a/src/app/api/messages/webhook/route.ts
+++ b/src/app/api/messages/webhook/route.ts
@@ -4,6 +4,7 @@ import { MessageSchema } from '@/types/message';
 import { MessageService } from '@/app/api/messages/services/message.service';
 import appConfig from '@/config/app';
 import { WebhookSchema } from '@/types/webhook';
+import { hasTimeExceeded } from '@/utils/hasTimeExceeded';
 
 export async function POST(request: NextRequest) {
   const rawBody = await request.text();
@@ -47,6 +48,10 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
+  }
+  if (hasTimeExceeded(payload.data.createdAt)) {
+    console.info('Autoresponse failed due to stale webhook timestamp. ', payload.data);
+    return NextResponse.json({});
   }
 
   const messageService = new MessageService();

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,6 +7,8 @@ export enum AUTO_RESPONSE {
   OFF = 'off',
 }
 
+export const AUTO_RESPONSE_TIME_THRESHOLD = 60;
+
 export const AUTO_RESPONSE_OPTIONS: SelectOption<$Enums.SettingType>[] = [
   {
     value: $Enums.SettingType.OUTSIDE_WORKING_HOURS,

--- a/src/utils/hasTimeExceeded.ts
+++ b/src/utils/hasTimeExceeded.ts
@@ -1,0 +1,9 @@
+import { AUTO_RESPONSE_TIME_THRESHOLD } from '@/constants';
+
+export function hasTimeExceeded(createdAt: string): boolean {
+  const thresholdInSeconds = AUTO_RESPONSE_TIME_THRESHOLD || 60;
+  const createdTime = new Date(createdAt).getTime();
+  const currentTime = Date.now();
+  const diffInSeconds = Math.abs(currentTime - createdTime) / 1000;
+  return diffInSeconds > thresholdInSeconds;
+}


### PR DESCRIPTION
## Issue 

- Autoresponder sending messages very late due to slow webhook invocation making it seem like autoresponder sending messages without being triggered by a client message.

## Changes 

- [x] created a hasTimeExceeded method which checks if the webhook's payload's createdAt timestamp is older than 60 seconds while auto responding.
- [x] If the webhook's payload's createdAt is older than 60 seconds, skipped the auto responding functionality.



