### PR TITLE
OUT-2397: Update copies for "Copilot" to "Assembly" in Autoresponder

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Copilot Platforms Inc.
+Copyright (c) 2024 - 2025 Copilot Platforms Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'Custom App',
-  description: 'Copilot Custom App Example',
+  description: 'Assembly Message Autoresponder app',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Changes:

- [x] Change metadata to reflect change from Copilot to Assembly branding